### PR TITLE
added an explicit cast to str for class_name in create_missing

### DIFF
--- a/pyactiveresource/activeresource.py
+++ b/pyactiveresource/activeresource.py
@@ -1025,7 +1025,7 @@ class ActiveResource(object):
 
         # If we made it this far, no such class was found
         if create_missing:
-            return type(class_name, (cls,), {'__module__': cls.__module__})
+            return type(str(class_name), (cls,), {'__module__': cls.__module__})
 
     # methods corresponding to Ruby's custom_methods
     def _custom_method_element_url(self, method_name, options):


### PR DESCRIPTION
found this bug while working on the shopify python API. Fix is simple just cast unicode to string before calling type(). 

@girasquid @dylanahsmith 
