### PR TITLE
added install requires and switched to setuptools so this actually works

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(name='pyactiveresource',
       url='https://github.com/Shopify/pyactiveresource/',
       packages=['pyactiveresource', 'pyactiveresource/tests'],
       license='MIT License',
-      test_requires=[
+      test_suite='pyactiveresource.tests',
+      tests_require=[
           'python-dateutil<2.0', # >= 2.0 is for python>=3.0
           'PyYAML',
       ],


### PR DESCRIPTION
If you install and are missing packages setup tools will now get them for you rather than just raising an error saying it doesn't understand install_requires. I also added what the install actually requires. 

I also added the tests module to the packages to install - I did this so that I can use the http_fake code for testing the shopify python api rather than duplicating code.

@girasquid @dylanahsmith 
