### PR TITLE
Prevent malformed prefixes caused by missing parameters

### DIFF
--- a/pyactiveresource/activeresource.py
+++ b/pyactiveresource/activeresource.py
@@ -734,15 +734,12 @@ class ActiveResource(six.with_metaclass(ResourceMeta, object)):
         """
         if options is None:
             options = {}
-        template = Template(cls.prefix_source)
+        path = re.sub('/$', '', cls.prefix_source)
+        template = Template(path)
         keys = cls._prefix_parameters()
         options = dict([(k, options.get(k, '')) for k in keys])
         prefix = template.safe_substitute(options)
-
-        prefix = re.sub(r'/+', '/', prefix)
-        if prefix.endswith('/'):
-            prefix = prefix[:-1]
-        return prefix
+        return re.sub('^/+', '', prefix)
 
     # Public instance methods
     def to_dict(self):

--- a/pyactiveresource/activeresource.py
+++ b/pyactiveresource/activeresource.py
@@ -734,8 +734,7 @@ class ActiveResource(six.with_metaclass(ResourceMeta, object)):
         """
         if options is None:
             options = {}
-        path = re.sub('/$', '', cls.prefix_source)
-        template = Template(path)
+        template = Template(cls.prefix_source)
         keys = cls._prefix_parameters()
         options = dict([(k, options.get(k, '')) for k in keys])
         prefix = template.safe_substitute(options)

--- a/pyactiveresource/activeresource.py
+++ b/pyactiveresource/activeresource.py
@@ -738,7 +738,12 @@ class ActiveResource(six.with_metaclass(ResourceMeta, object)):
         template = Template(path)
         keys = cls._prefix_parameters()
         options = dict([(k, options.get(k, '')) for k in keys])
-        return template.safe_substitute(options)
+        prefix = template.safe_substitute(options)
+
+        prefix = re.sub(r'/+', '/', prefix)
+        if prefix.endswith('/'):
+            prefix = prefix[:-1]
+        return prefix
 
     # Public instance methods
     def to_dict(self):

--- a/test/activeresource_test.py
+++ b/test/activeresource_test.py
@@ -234,6 +234,14 @@ class ActiveResourceTest(unittest.TestCase):
         nobody = self.person.find(store_id=1, name='Ralph')
         self.assertEqual([], nobody)
 
+    def test_prefix_format(self):
+        self.http.respond_to(
+            'GET', '/people.json?name=Ralph', {},
+            util.to_json([], root='people'))
+        self.person.prefix_source = '/${store_type}/${store_id}/'
+        nobody = self.person.find(name='Ralph')
+        self.assertEqual([], nobody)
+
     def test_save(self):
         # Return an object with id for a post(save) request.
         self.http.respond_to(

--- a/test/activeresource_test.py
+++ b/test/activeresource_test.py
@@ -238,7 +238,7 @@ class ActiveResourceTest(unittest.TestCase):
         self.http.respond_to(
             'GET', '/people.json?name=Ralph', {},
             util.to_json([], root='people'))
-        self.person.prefix_source = '/${store_type}/${store_id}/'
+        self.person.prefix_source = '/${store_id}/'
         nobody = self.person.find(name='Ralph')
         self.assertEqual([], nobody)
 


### PR DESCRIPTION
When prefix parameters are expected, but do not exist, the resulting prefix may contain repeating slashes and end with a slash. If the prefix ends with a slash, the hostname is dropped from the request URL.

To fix this, I collapsed repeating slashes and removed any trailing slashes.