### PR TITLE
Fix for issue with Python 2.7.9 and HTTPS mocking.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 tags
 /pyactiveresource.egg-info/
 *.egg
+.idea

--- a/pyactiveresource/testing/http_fake.py
+++ b/pyactiveresource/testing/http_fake.py
@@ -61,6 +61,10 @@ class TestHandler(urllib.request.HTTPHandler, urllib.request.HTTPSHandler):
     request = None
     site = ''
 
+    def __init__(self, debuglevel=0, context=None):
+        self._debuglevel = debuglevel
+        self._context = context
+
     @classmethod
     def set_response(cls, response):
         """Set a static response to be returned for all requests.

--- a/pyactiveresource/testing/http_fake.py
+++ b/pyactiveresource/testing/http_fake.py
@@ -61,9 +61,10 @@ class TestHandler(urllib.request.HTTPHandler, urllib.request.HTTPSHandler):
     request = None
     site = ''
 
-    def __init__(self, debuglevel=0, context=None):
+    def __init__(self, debuglevel=0, **kwargs):
         self._debuglevel = debuglevel
-        self._context = context
+        self._context = kwargs.get('context')
+        self._check_hostname = kwargs.get('check_hostname')
 
     @classmethod
     def set_response(cls, response):

--- a/test/connection_test.py
+++ b/test/connection_test.py
@@ -108,7 +108,7 @@ class ConnectionTest(unittest.TestCase):
     def test_get(self):
         person = util.to_json({'id': 1, 'name': 'Matz'}, root='person')
         self.http.respond_to(
-            'GET', 'http://localhost/people/1.json', {}, person)
+            'GET', '/people/1.json', {}, person)
         self.connection.format = formats.JSONFormat
         response = self.connection.get('/people/1.json')
         self.assertEqual(response['name'], 'Matz')
@@ -116,18 +116,18 @@ class ConnectionTest(unittest.TestCase):
     def test_get_with_xml_format(self):
         person = util.to_xml({'id': 1, 'name': 'Matz'}, root='person')
         self.http.respond_to(
-            'GET', 'http://localhost/people/1.xml', {}, person)
+            'GET', '/people/1.xml', {}, person)
         self.connection.format = formats.XMLFormat
         response = self.connection.get('/people/1.xml')
         self.assertEqual(response['name'], 'Matz')
 
     def test_head(self):
-        self.http.respond_to('HEAD', 'http://localhost/people/1.json', {}, '')
+        self.http.respond_to('HEAD', '/people/1.json', {}, '')
         self.assertFalse(self.connection.head('/people/1.json').body)
 
     def test_get_with_header(self):
         self.http.respond_to(
-            'GET', 'http://localhost/people/2.json', self.header, self.david)
+            'GET', '/people/2.json', self.header, self.david)
         david = self.connection.get('/people/2.json', self.header)
         self.assertEqual(david['name'], 'David')
   

--- a/test/https_connection_test.py
+++ b/test/https_connection_test.py
@@ -1,0 +1,17 @@
+__author__ = 'Gavin Ballard (gavin@gavinballard.com)'
+
+
+from .connection_test import ConnectionTest
+from pyactiveresource import connection
+
+
+class HTTPSConnectionTest(ConnectionTest):
+    """
+    This class subclasses the ConnectionTest and runs all of the same tests, but does it over HTTPS rather than HTTP.
+    """
+
+    def setUp(self):
+        super(HTTPSConnectionTest, self).setUp()
+        # Override the base site URL and re-create the connection.
+        self.http.site = 'https://localhost'
+        self.connection = connection.Connection(self.http.site)


### PR DESCRIPTION
The `urllib2` library introduced a `_context` instance variable to the `HTTPSHandler` in Python 2.7.9. This causes some issues with the `TestHandler` class in `http_fake.py` (see https://github.com/Shopify/shopify_python_api/pull/86 and https://github.com/Shopify/shopify_python_api/pull/89).

This PR:
- Adds a `HTTPSConnectionTest` class which mirrors the tests in `ConnectionTest` but runs them over HTTPS, exposing this issue within the `pyactiveresource` test suite;
- Provides a fix for the issue with a simple override of `__init__()` in the `TestHandler` class.
