### PR TITLE
add code to pyactive resource errors

### DIFF
--- a/pyactiveresource/activeresource.py
+++ b/pyactiveresource/activeresource.py
@@ -33,6 +33,7 @@ class Errors(object):
         """
         self.base = base
         self.errors = {}
+        self.code = 0
 
     @property
     def size(self):
@@ -71,6 +72,7 @@ class Errors(object):
             None
         """
         self.errors = {}
+        self.code = 0
 
     def from_array(self, messages):
         attribute_keys = self.base.attributes.keys()
@@ -830,6 +832,7 @@ class ActiveResource(six.with_metaclass(ResourceMeta, object)):
                 self.errors.from_xml(err.response.body)
             elif self.klass.format == formats.JSONFormat:
                 self.errors.from_json(err.response.body)
+            self.errors.code = err.code;
             return False
         try:
             attributes = self.klass.format.decode(response.body)


### PR DESCRIPTION
Errors.code helps to differentiate actions when Shopify replies with error