### PR TITLE
use the readme as the project description on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,13 @@ if sys.version_info >= (3,):
 else:
     python_dateutils_version = 'python-dateutil<2.0'
 
+with open('README.md', 'r') as f:
+    long_description = f.read()
 
 setup(name='pyactiveresource',
       version=version,
       description='ActiveResource for Python',
+      long_description=long_description,
       author='Shopify',
       author_email='developers@shopify.com',
       url='https://github.com/Shopify/pyactiveresource/',
@@ -37,7 +40,7 @@ setup(name='pyactiveresource',
                    'Programming Language :: Python :: 3',
                    'Programming Language :: Python :: 3.3',
                    'Programming Language :: Python :: 3.4',
-                   'Topic :: Software Development', 
+                   'Topic :: Software Development',
                    'Topic :: Software Development :: Libraries',
                    'Topic :: Software Development :: Libraries :: Python Modules']
     )


### PR DESCRIPTION
Ive been using the ShopifyAPI package and I was looking for a way to mock out requests during our test runs.When I went to [PyPi](https://pypi.org/project/pyactiveresource/) I found that this project has an `UNKNOWN` description.

Next time a release is made, an updated description will show up.

Im also looking for the recommended way to mock out requests and if there Is one, I can get the readme updated here or in the [ShopifyAPI](https://github.com/Shopify/shopify_python_api) project.