### PR TITLE
Add debug logging in case of HTTPError response.

### DIFF
--- a/pyactiveresource/connection.py
+++ b/pyactiveresource/connection.py
@@ -285,6 +285,9 @@ class Connection(object):
             try:
                 http_response = self._handle_error(self._urlopen(request))
             except urllib.error.HTTPError as err:
+                self.log.debug('HTTPError(code=%d, reason=%s)', err.code, err.reason)
+                if hasattr(err, "headers"):  # available since version 3.4.
+                    self.log.debug('HTTPError headers:\n%s', err.headers)
                 http_response = self._handle_error(err)
             except urllib.error.URLError as err:
                 raise Error(err, url)


### PR DESCRIPTION
To trouble shoot the errors support asks for `x-request-id`
headers from the response.
This change allows to find it in logs.

Note: unfortunately headers are 'plain' headers and not a dict. Means log message is not in one line. Hope this is still acceptable, since it is debugging scenario.  