### PR TITLE
Python 2 and 3 compatibility

### DIFF
--- a/pyactiveresource/collection.py
+++ b/pyactiveresource/collection.py
@@ -22,7 +22,7 @@ class Collection(list):
 
     def copy(self):
         """Override list.copy so that it returns a Collection."""
-        copied_list = super(Collection, self).copy()
+        copied_list = list(self)
         return Collection(copied_list, metadata=copy.deepcopy(self._metadata))
 
     def __eq__(self, other):

--- a/pyactiveresource/util.py
+++ b/pyactiveresource/util.py
@@ -415,7 +415,7 @@ def xml_to_dict(xmlobj, saveroot=True):
             raise ImportError('PyYaml is not installed: http://pyyaml.org/')
         return yaml.safe_load(element.text)
     elif element_type == 'base64binary':
-        return base64.decodestring(element.text.encode('ascii'))
+        return base64.b64decode(element.text.encode('ascii'))
     elif element_type == 'file':
         content_type = element.get('content_type',
                                    'application/octet-stream')


### PR DESCRIPTION
`base64.decodestring` fails in Python 3
`super(Collection, self).copy()` (list.copy()) fails in Python 2