### PR TITLE
Add support for certifi to be used on urllib requests

### DIFF
--- a/pyactiveresource/connection.py
+++ b/pyactiveresource/connection.py
@@ -3,10 +3,12 @@
 """A connection object to interface with REST services."""
 
 import base64
+import certifi
 import logging
 import socket
 import sys
 import six
+import ssl
 from six.moves import urllib
 from pyactiveresource import formats
 
@@ -313,9 +315,16 @@ class Connection(object):
             urllib.error.URLError on IO errors.
         """
         if _urllib_has_timeout():
-          return urllib.request.urlopen(request, timeout=self.timeout)
+          return urllib.request.urlopen(
+              request,
+              timeout=self.timeout,
+              context=ssl.create_default_context(cafile=certifi.where())
+          )
         else:
-          return urllib.request.urlopen(request)
+          return urllib.request.urlopen(
+              request,
+              context=ssl.create_default_context(cafile=certifi.where())
+          )
 
     def get(self, path, headers=None):
         """Perform an HTTP get request.

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='pyactiveresource',
       license='MIT License',
       test_suite='test',
       install_requires=[
+          'certifi',
           'six',
       ],
       tests_require=[


### PR DESCRIPTION
We are having some issues coming from this library because it is taking the wrong certificate. Enforcing the use of `certifi`, which has become a standard in the Python industry, would solve that problem. 

I'll leave this PR here mainly as an idea, as there are better ways of solving this problem. This will enforce the use of `certifi` but I'm sure you rather control that yourself depending on the situation.